### PR TITLE
feat: add UniFi DNS record management for infrastructure endpoints

### DIFF
--- a/.env.op
+++ b/.env.op
@@ -46,3 +46,11 @@ TF_VAR_cloudflare_zone_id=op://homelab/cloudflare/zone_id
 # =============================================================================
 TF_VAR_cluster_name=op://homelab/network-config/cluster_name
 TF_VAR_environment=op://homelab/network-config/environment
+
+# =============================================================================
+# UniFi Configuration
+# =============================================================================
+UNIFI_API=op://homelab/unifi/api_url
+UNIFI_USERNAME=op://homelab/unifi/username
+UNIFI_PASSWORD=op://homelab/unifi/password
+UNIFI_SITE=op://homelab/unifi/site

--- a/terragrunt/environments/homelab/env.hcl
+++ b/terragrunt/environments/homelab/env.hcl
@@ -94,6 +94,13 @@ locals {
   # Base FQDN
   base_fqdn = "ryanmcafee.com"
 
+  # UniFi configuration (credentials via environment variables)
+  unifi_api_url  = get_env("UNIFI_API", "")
+  unifi_username = get_env("UNIFI_USERNAME", "")
+  unifi_password = get_env("UNIFI_PASSWORD", "")
+  unifi_insecure = true
+  unifi_site     = get_env("UNIFI_SITE", "default")
+
   # Resource allocation
   # Control plane: 2 nodes x 8GB = 16GB total
   # Workers: 3 nodes x 32GB = 96GB total

--- a/terragrunt/environments/homelab/proxmox-cluster/terragrunt.hcl
+++ b/terragrunt/environments/homelab/proxmox-cluster/terragrunt.hcl
@@ -1,0 +1,37 @@
+# Homelab - Proxmox Cluster DNS
+# Provisions DNS records for Proxmox cluster endpoints
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "env" {
+  path   = find_in_parent_folders("env.hcl")
+  expose = true
+}
+
+terraform {
+  source = "../../../modules//proxmox-cluster"
+}
+
+# Configure UniFi provider
+generate "provider_unifi" {
+  path      = "provider_unifi.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "unifi" {
+  api_url        = "${include.env.locals.unifi_api_url}"
+  username       = "${include.env.locals.unifi_username}"
+  password       = "${include.env.locals.unifi_password}"
+  allow_insecure = ${include.env.locals.unifi_insecure}
+  site           = "${include.env.locals.unifi_site}"
+}
+EOF
+}
+
+inputs = {
+  dns_entries = [
+    { fqdn = "proxmox.home.lab", type = "A", host = include.env.locals.proxmox_host },
+    { fqdn = "proxmox.${include.env.locals.base_fqdn}", type = "A", host = include.env.locals.proxmox_host }
+  ]
+}

--- a/terragrunt/environments/homelab/proxmox-zfs-pool/terragrunt.hcl
+++ b/terragrunt/environments/homelab/proxmox-zfs-pool/terragrunt.hcl
@@ -14,6 +14,15 @@ terraform {
   source = "../../../modules//proxmox-zfs-pool"
 }
 
+dependency "proxmox_cluster" {
+  config_path = "../proxmox-cluster"
+
+  mock_outputs = {
+    dns_records = {}
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
 # Configure Proxmox provider
 # API token is read from TF_VAR_proxmox_api_token_id and TF_VAR_proxmox_api_token_secret via env.hcl
 generate "provider_proxmox" {

--- a/terragrunt/environments/homelab/talos-cluster-config/terragrunt.hcl
+++ b/terragrunt/environments/homelab/talos-cluster-config/terragrunt.hcl
@@ -56,6 +56,21 @@ provider "onepassword" {
 EOF
 }
 
+# Configure UniFi provider for DNS records
+generate "provider_unifi" {
+  path      = "provider_unifi.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "unifi" {
+  api_url        = "${include.env.locals.unifi_api_url}"
+  username       = "${include.env.locals.unifi_username}"
+  password       = "${include.env.locals.unifi_password}"
+  allow_insecure = ${include.env.locals.unifi_insecure}
+  site           = "${include.env.locals.unifi_site}"
+}
+EOF
+}
+
 inputs = {
   # Pass through from talos-cluster module
   client_configuration         = dependency.talos_cluster.outputs.client_configuration
@@ -76,4 +91,10 @@ inputs = {
   # 1Password vault for storing kubeconfig/talosconfig
   # Set via environment variable TF_VAR_onepassword_vault_id or leave empty to skip
   onepassword_vault_id = get_env("TF_VAR_onepassword_vault_id", "")
+
+  # DNS records for Kubernetes API
+  dns_entries = [
+    { fqdn = "k8s.home.lab", type = "A", host = include.env.locals.cluster_endpoint },
+    { fqdn = "k8s.${include.env.locals.base_fqdn}", type = "A", host = include.env.locals.cluster_endpoint }
+  ]
 }

--- a/terragrunt/environments/homelab/truenas/terragrunt.hcl
+++ b/terragrunt/environments/homelab/truenas/terragrunt.hcl
@@ -38,6 +38,21 @@ provider "proxmox" {
 EOF
 }
 
+# Configure UniFi provider for DNS records
+generate "provider_unifi" {
+  path      = "provider_unifi.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "unifi" {
+  api_url        = "${include.env.locals.unifi_api_url}"
+  username       = "${include.env.locals.unifi_username}"
+  password       = "${include.env.locals.unifi_password}"
+  allow_insecure = ${include.env.locals.unifi_insecure}
+  site           = "${include.env.locals.unifi_site}"
+}
+EOF
+}
+
 inputs = {
   vm_name   = "truenas"
   vm_id     = include.env.locals.truenas_vm_id
@@ -75,4 +90,12 @@ inputs = {
   truenas_api_url = "https://${include.env.locals.truenas_ip}"
 
   tags = ["homelab", "storage", "truenas"]
+
+  # DNS records for TrueNAS
+  dns_entries = [
+    { fqdn = "truenas.home.lab", type = "A", host = include.env.locals.truenas_ip },
+    { fqdn = "truenas.${include.env.locals.base_fqdn}", type = "A", host = include.env.locals.truenas_ip },
+    { fqdn = "nas.home.lab", type = "A", host = include.env.locals.truenas_ip },
+    { fqdn = "nas.${include.env.locals.base_fqdn}", type = "A", host = include.env.locals.truenas_ip }
+  ]
 }

--- a/terragrunt/modules/proxmox-cluster/main.tf
+++ b/terragrunt/modules/proxmox-cluster/main.tf
@@ -1,0 +1,24 @@
+/**
+ * Proxmox Cluster DNS Module
+ *
+ * Provisions DNS records for Proxmox cluster endpoints via UniFi controller.
+ */
+
+terraform {
+  required_version = ">= 1.7.0"
+}
+
+resource "unifi_dns_record" "this" {
+  for_each = { for entry in var.dns_entries : entry.fqdn => entry }
+
+  name        = each.value.fqdn
+  record_type = each.value.type
+  value       = each.value.host
+  enabled     = true
+  ttl         = var.dns_ttl
+  port        = 0 # Required to avoid provider inconsistency bug
+
+  lifecycle {
+    ignore_changes = [port]
+  }
+}

--- a/terragrunt/modules/proxmox-cluster/outputs.tf
+++ b/terragrunt/modules/proxmox-cluster/outputs.tf
@@ -1,0 +1,4 @@
+output "dns_records" {
+  description = "Map of FQDN to DNS record ID"
+  value       = { for fqdn, record in unifi_dns_record.this : fqdn => record.id }
+}

--- a/terragrunt/modules/proxmox-cluster/variables.tf
+++ b/terragrunt/modules/proxmox-cluster/variables.tf
@@ -1,0 +1,15 @@
+variable "dns_entries" {
+  description = "List of DNS entries to create"
+  type = list(object({
+    fqdn = string
+    type = string
+    host = string
+  }))
+  default = []
+}
+
+variable "dns_ttl" {
+  description = "TTL for DNS records in seconds"
+  type        = number
+  default     = 300
+}

--- a/terragrunt/modules/talos-cluster-config/main.tf
+++ b/terragrunt/modules/talos-cluster-config/main.tf
@@ -212,3 +212,19 @@ resource "onepassword_item" "talosconfig" {
     ignore_changes = [vault]
   }
 }
+
+# DNS Records for Kubernetes API
+resource "unifi_dns_record" "this" {
+  for_each = { for entry in var.dns_entries : entry.fqdn => entry }
+
+  name        = each.value.fqdn
+  record_type = each.value.type
+  value       = each.value.host
+  enabled     = true
+  ttl         = var.dns_ttl
+  port        = 0 # Required to avoid provider inconsistency bug
+
+  lifecycle {
+    ignore_changes = [port]
+  }
+}

--- a/terragrunt/modules/talos-cluster-config/outputs.tf
+++ b/terragrunt/modules/talos-cluster-config/outputs.tf
@@ -38,3 +38,8 @@ output "cluster_ca_certificate" {
   value       = base64decode(yamldecode(talos_cluster_kubeconfig.this.kubeconfig_raw)["clusters"][0]["cluster"]["certificate-authority-data"])
   sensitive   = true
 }
+
+output "dns_records" {
+  description = "Map of FQDN to DNS record ID"
+  value       = { for fqdn, record in unifi_dns_record.this : fqdn => record.id }
+}

--- a/terragrunt/modules/talos-cluster-config/variables.tf
+++ b/terragrunt/modules/talos-cluster-config/variables.tf
@@ -114,3 +114,20 @@ variable "cluster_endpoint" {
   type        = string
   default     = ""
 }
+
+# DNS Configuration
+variable "dns_entries" {
+  description = "List of DNS entries to create for Kubernetes API"
+  type = list(object({
+    fqdn = string
+    type = string
+    host = string
+  }))
+  default = []
+}
+
+variable "dns_ttl" {
+  description = "TTL for DNS records in seconds"
+  type        = number
+  default     = 300
+}

--- a/terragrunt/modules/truenas/main.tf
+++ b/terragrunt/modules/truenas/main.tf
@@ -170,3 +170,21 @@ resource "null_resource" "wait_for_truenas" {
     EOF
   }
 }
+
+# DNS Records for TrueNAS
+resource "unifi_dns_record" "this" {
+  for_each = { for entry in var.dns_entries : entry.fqdn => entry }
+
+  name        = each.value.fqdn
+  record_type = each.value.type
+  value       = each.value.host
+  enabled     = true
+  ttl         = var.dns_ttl
+  port        = 0 # Required to avoid provider inconsistency bug
+
+  depends_on = [proxmox_virtual_environment_vm.truenas]
+
+  lifecycle {
+    ignore_changes = [port]
+  }
+}

--- a/terragrunt/modules/truenas/outputs.tf
+++ b/terragrunt/modules/truenas/outputs.tf
@@ -22,3 +22,8 @@ output "iso_id" {
   description = "The ID of the downloaded TrueNAS ISO"
   value       = proxmox_virtual_environment_download_file.truenas_iso.id
 }
+
+output "dns_records" {
+  description = "Map of FQDN to DNS record ID"
+  value       = { for fqdn, record in unifi_dns_record.this : fqdn => record.id }
+}

--- a/terragrunt/modules/truenas/variables.tf
+++ b/terragrunt/modules/truenas/variables.tf
@@ -153,3 +153,20 @@ variable "truenas_api_url" {
   type        = string
   default     = ""
 }
+
+# DNS Configuration
+variable "dns_entries" {
+  description = "List of DNS entries to create for TrueNAS"
+  type = list(object({
+    fqdn = string
+    type = string
+    host = string
+  }))
+  default = []
+}
+
+variable "dns_ttl" {
+  description = "TTL for DNS records in seconds"
+  type        = number
+  default     = 300
+}

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -64,6 +64,10 @@ generate "provider" {
           source  = "1Password/onepassword"
           version = "~> 2.1.0"
         }
+        unifi = {
+          source  = "ubiquiti-community/unifi"
+          version = "~> 0.41.0"
+        }
       }
     }
   EOF


### PR DESCRIPTION
## Summary
- Add UniFi provider support to Terragrunt for DNS record management
- Create `proxmox-cluster` module for Proxmox DNS records
- Update `truenas` and `talos-cluster-config` modules with DNS provisioning
- Add UniFi secrets configuration to `.env.op` for 1Password integration

## DNS Records Provisioned
| FQDN | IP Address |
|------|------------|
| proxmox.home.lab | 172.16.100.250 |
| proxmox.ryanmcafee.com | 172.16.100.250 |
| truenas.home.lab | 172.16.100.150 |
| truenas.ryanmcafee.com | 172.16.100.150 |
| nas.home.lab | 172.16.100.150 |
| nas.ryanmcafee.com | 172.16.100.150 |
| k8s.home.lab | 172.16.100.10 |
| k8s.ryanmcafee.com | 172.16.100.10 |

## Required Setup
Create a 1Password item `unifi` in `homelab` vault with fields:
- `api_url` - UniFi controller URL
- `username` - Terraform service account
- `password` - Service account password
- `site` - UniFi site name (typically `default`)

## Test plan
- [x] `terragrunt validate` passes on all modified modules
- [ ] `terragrunt plan` shows expected DNS records
- [ ] `terragrunt apply` creates DNS records in UniFi controller