### PR TITLE
fix: resolve kubernetes pod scheduling issues

### DIFF
--- a/charts/addons/templates/1password-operator.yaml
+++ b/charts/addons/templates/1password-operator.yaml
@@ -16,22 +16,18 @@ spec:
     chart: {{ index .Values "1password-operator" "chart" "name" }}
     targetRevision: {{ index .Values "1password-operator" "chart" "version" }}
     helm:
-      releaseName: onepassword-connect-operator
+      releaseName: onepassword-connect
       values: |
         operator:
           create: true
+          autoRestart: true
           resources:
             {{- toYaml (index .Values "1password-operator" "resources" "operator") | nindent 12 }}
 
         connect:
           create: true
-          host: {{ index .Values "1password-operator" "connect" "host" }}
-
-          # Credentials provided via Kubernetes secret
-          # This secret must be created manually or via Terragrunt
-          credentialsName: onepassword-credentials
+          credentials: onepassword-credentials
           credentialsKey: 1password-credentials.json
-
           resources:
             {{- toYaml (index .Values "1password-operator" "resources" "connect") | nindent 12 }}
 

--- a/charts/addons/templates/cert-manager.yaml
+++ b/charts/addons/templates/cert-manager.yaml
@@ -1,4 +1,17 @@
 {{- if index .Values "cert-manager" "enabled" }}
+{{- if (index .Values "cert-manager" "cloudflare" "enabled") }}
+---
+# OnePasswordItem syncs the Cloudflare API token from 1Password vault
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflare-api-token
+  namespace: {{ index .Values "cert-manager" "namespace" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  itemPath: {{ index .Values "cert-manager" "cloudflare" "onePasswordItemPath" | quote }}
+{{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/charts/addons/templates/external-dns.yaml
+++ b/charts/addons/templates/external-dns.yaml
@@ -1,4 +1,17 @@
 {{- if index .Values "external-dns" "enabled" }}
+{{- if eq (index .Values "external-dns" "provider") "cloudflare" }}
+---
+# OnePasswordItem syncs the Cloudflare API token from 1Password vault
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflare-api-token
+  namespace: {{ index .Values "external-dns" "namespace" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  itemPath: {{ index .Values "external-dns" "cloudflare" "onePasswordItemPath" | quote }}
+{{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/charts/addons/templates/traefik.yaml
+++ b/charts/addons/templates/traefik.yaml
@@ -1,4 +1,17 @@
 {{- if .Values.traefik.enabled }}
+{{- if .Values.traefik.cloudflare.enabled }}
+---
+# OnePasswordItem syncs the Cloudflare API token from 1Password vault
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflare-api-token
+  namespace: {{ .Values.traefik.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  itemPath: {{ .Values.traefik.cloudflare.onePasswordItemPath | quote }}
+{{- end }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/charts/addons/values-homelab.yaml
+++ b/charts/addons/values-homelab.yaml
@@ -158,12 +158,13 @@ democratic-csi:
   driver: freenas-nfs
 
   truenas:
-    endpoint: https://truenas.ryanmcafee.com
-    allowInsecure: false
+    # Use IP address instead of hostname since internal DNS is not resolvable from cluster
+    endpoint: https://172.16.100.150
+    allowInsecure: true  # Required when using IP (no valid TLS cert for IP)
     apiKey: ""  # Provided via 1Password operator
 
   nfs:
-    shareHost: truenas.ryanmcafee.com
+    shareHost: 172.16.100.150
     shareAllow: 172.16.100.0/24
     parent: storage/k8s
 
@@ -209,9 +210,9 @@ local-path-provisioner:
   namespace: onepassword-operator
 
   chart:
-    name: onepassword-connect-operator
+    name: connect
     repo: https://1password.github.io/connect-helm-charts
-    version: 1.15.1
+    version: 2.2.1
 
   connect:
     credentialsJson: ""
@@ -259,6 +260,7 @@ cert-manager:
     enabled: true
     email: admin@ryanmcafee.com
     apiToken: ""
+    onePasswordItemPath: vaults/homelab/items/cloudflare-api-token
 
   resources:
     requests:
@@ -305,6 +307,7 @@ external-dns:
   cloudflare:
     apiToken: ""
     proxied: true
+    onePasswordItemPath: vaults/homelab/items/cloudflare-api-token
 
   domainFilters:
     - ryanmcafee.com
@@ -500,3 +503,7 @@ traefik:
           target:
             type: Utilization
             averageUtilization: 80
+
+  cloudflare:
+    enabled: true
+    onePasswordItemPath: vaults/homelab/items/cloudflare-api-token

--- a/terragrunt/modules/talos-cluster-config/main.tf
+++ b/terragrunt/modules/talos-cluster-config/main.tf
@@ -44,8 +44,9 @@ locals {
 }
 
 # Trigger resource that tracks when bootstrap should re-run
-# When the input changes (e.g., new machine secrets), this resource is replaced,
-# which in turn triggers the bootstrap resource to be replaced via lifecycle
+# IMPORTANT: Only trigger on machine_secrets changes (new cluster creation)
+# Config changes (DNS, patches, etc.) should NOT trigger re-bootstrap
+# as the cluster just needs configs re-applied, not a fresh bootstrap
 resource "terraform_data" "bootstrap_trigger" {
   count = var.bootstrap_cluster ? 1 : 0
   input = var.bootstrap_trigger
@@ -79,7 +80,6 @@ resource "talos_machine_bootstrap" "this" {
 
   depends_on = [
     talos_machine_configuration_apply.controlplane,
-    talos_machine_configuration_apply.worker
   ]
 
   client_configuration = var.client_configuration

--- a/terragrunt/modules/talos-cluster/main.tf
+++ b/terragrunt/modules/talos-cluster/main.tf
@@ -130,6 +130,7 @@ data "talos_machine_configuration" "controlplane" {
       yamlencode({
         machine = {
           network = {
+            nameservers = var.dns_servers
             interfaces = [{
               deviceSelector = {
                 hardwareAddr = local.node_mac_addresses[each.key]
@@ -199,6 +200,7 @@ data "talos_machine_configuration" "worker" {
       yamlencode({
         machine = {
           network = {
+            nameservers = var.dns_servers
             interfaces = [{
               deviceSelector = {
                 hardwareAddr = local.node_mac_addresses[each.key]


### PR DESCRIPTION
## Summary
- Fix 1Password operator chart reference (renamed upstream from onepassword-connect-operator to connect, version 2.2.1)
- Fix democratic-csi DNS resolution by using TrueNAS IP instead of hostname
- Add OnePasswordItem resources to sync cloudflare-api-token from 1Password
- Fix Talos DNS configuration (nameservers weren't being applied to machine configs)
- Fix bootstrap trigger logic to only re-bootstrap on new cluster creation

## Test Plan
- [x] Cluster nodes all Ready
- [x] ArgoCD deployed and syncing
- [ ] 1Password operator deploys correctly
- [ ] democratic-csi connects to TrueNAS
- [ ] external-dns gets cloudflare token from 1Password