### PR TITLE
fix(external-dns-unifi): add CRD source for DNSEndpoint support

### DIFF
--- a/charts/addons/templates/external-dns-unifi.yaml
+++ b/charts/addons/templates/external-dns-unifi.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
 ---
-# OnePasswordItem for UniFi API credentials
+# OnePasswordItem for UniFi API credentials (shared by both instances)
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
@@ -18,10 +18,11 @@ metadata:
 spec:
   itemPath: {{ index .Values "external-dns-unifi" "onePasswordItemPath" | quote }}
 ---
+# Instance 1: CRD source for DNSEndpoint resources
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: external-dns-unifi
+  name: external-dns-unifi-crd
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "4"
@@ -34,9 +35,93 @@ spec:
     chart: external-dns
     targetRevision: {{ index .Values "external-dns-unifi" "chart" "version" }}
     helm:
-      releaseName: external-dns-unifi
+      releaseName: external-dns-unifi-crd
       values: |
-        fullnameOverride: external-dns-unifi
+        fullnameOverride: external-dns-unifi-crd
+
+        provider:
+          name: webhook
+          webhook:
+            image:
+              repository: ghcr.io/kashalls/external-dns-unifi-webhook
+              tag: {{ index .Values "external-dns-unifi" "webhook" "version" }}
+            env:
+              - name: UNIFI_HOST
+                value: {{ index .Values "external-dns-unifi" "unifi" "host" | quote }}
+              - name: UNIFI_EXTERNAL_CONTROLLER
+                value: "false"
+              - name: UNIFI_SKIP_TLS_VERIFY
+                value: "true"
+              - name: UNIFI_API_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: unifi-api-credentials
+                    key: api_key
+              - name: LOG_LEVEL
+                value: "info"
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8080
+              initialDelaySeconds: 10
+              timeoutSeconds: 5
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: 8080
+              initialDelaySeconds: 10
+              timeoutSeconds: 5
+
+        extraArgs:
+          - --source=crd
+          - --txt-owner-id=homelab-unifi-crd
+
+        domainFilters:
+          {{- range (index .Values "external-dns-unifi" "domainFilters") }}
+          - {{ . }}
+          {{- end }}
+
+        policy: sync
+        registry: txt
+
+        resources:
+          {{- toYaml (index .Values "external-dns-unifi" "resources") | nindent 10 }}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ index .Values "external-dns-unifi" "namespace" }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 0
+---
+# Instance 2: Ingress/Service sources with annotation filter
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-dns-unifi-ingress
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes-sigs.github.io/external-dns/
+    chart: external-dns
+    targetRevision: {{ index .Values "external-dns-unifi" "chart" "version" }}
+    helm:
+      releaseName: external-dns-unifi-ingress
+      values: |
+        fullnameOverride: external-dns-unifi-ingress
 
         provider:
           name: webhook
@@ -75,7 +160,7 @@ spec:
           - --source=ingress
           - --source=service
           - --annotation-filter=external-dns.alpha.kubernetes.io/hostname
-          - --txt-owner-id=homelab-unifi
+          - --txt-owner-id=homelab-unifi-ingress
 
         domainFilters:
           {{- range (index .Values "external-dns-unifi" "domainFilters") }}

--- a/docs/project_notes/bugs.md
+++ b/docs/project_notes/bugs.md
@@ -19,6 +19,12 @@ Each entry should include:
 - **Prevention**: Test oauth2-proxy separately before enabling on production ingresses
 - **Commit**: 18eacc9
 
+### 2026-01-28 - external-dns-unifi not creating DNS records for DNSEndpoint CRDs
+- **Issue**: DNSEndpoint resources (e.g., traefik-dashboard) not creating internal DNS records in UniFi
+- **Root Cause**: external-dns-unifi was configured with `--source=ingress` and `--source=service` but missing `--source=crd`. The `--annotation-filter` doesn't apply to CRD sources (they define DNS in spec, not annotations)
+- **Solution**: Split into two instances: `external-dns-unifi-crd` (CRD source only) and `external-dns-unifi-ingress` (ingress/service with annotation filter). Each has separate txt-owner-id to avoid conflicts
+- **Prevention**: For split-horizon DNS, use dedicated external-dns instances per source type when annotation filtering is needed
+
 ### 2025-01-27 - Duplicate cloudflare-api-token OnePasswordItem in traefik
 - **Issue**: Traefik addon had duplicate OnePasswordItem definition for cloudflare-api-token
 - **Root Cause**: Copy-paste error when adding external-dns alongside traefik


### PR DESCRIPTION
## Summary
Split external-dns-unifi into two dedicated instances for cleaner split-horizon DNS:

| Instance | Sources | Annotation Filter | txt-owner-id |
|----------|---------|-------------------|--------------|
| `external-dns-unifi-crd` | CRD | No | `homelab-unifi-crd` |
| `external-dns-unifi-ingress` | ingress, service | Yes | `homelab-unifi-ingress` |

## Root Cause
The original single instance couldn't effectively handle both:
- DNSEndpoint CRDs (which define DNS in spec, not annotations)
- Ingress/Service resources (which use annotation filter for selective DNS)

## Architecture
- Both instances share the same namespace and 1Password credentials
- Separate txt-owner-id prevents record ownership conflicts
- CRD instance processes all DNSEndpoint resources in the domain
- Ingress instance only processes resources with `external-dns.alpha.kubernetes.io/hostname` annotation

## Test plan
- [ ] ArgoCD creates both `external-dns-unifi-crd` and `external-dns-unifi-ingress` applications
- [ ] Both pods start successfully in the external-dns-unifi namespace
- [ ] traefik.ryanmcafee.com DNS record appears in UniFi (from CRD instance)
- [ ] Ingress resources with annotation create DNS records (from ingress instance)