### PR TITLE
fix(external-dns-unifi): use sources value for proper RBAC generation

### DIFF
--- a/charts/addons/templates/external-dns-unifi.yaml
+++ b/charts/addons/templates/external-dns-unifi.yaml
@@ -72,8 +72,10 @@ spec:
               initialDelaySeconds: 10
               timeoutSeconds: 5
 
+        sources:
+          - crd
+
         extraArgs:
-          - --source=crd
           - --txt-owner-id=homelab-unifi-crd
 
         domainFilters:
@@ -156,9 +158,11 @@ spec:
               initialDelaySeconds: 10
               timeoutSeconds: 5
 
+        sources:
+          - ingress
+          - service
+
         extraArgs:
-          - --source=ingress
-          - --source=service
           - --annotation-filter=external-dns.alpha.kubernetes.io/hostname
           - --txt-owner-id=homelab-unifi-ingress
 


### PR DESCRIPTION
## Summary
The helm chart generates RBAC rules based on the `sources` value, not `extraArgs`. Moving source configuration to the proper helm value ensures ClusterRole includes permissions for `externaldns.k8s.io` API group.

## Changes
- Use `sources` helm value instead of `--source=` in extraArgs
- This triggers proper RBAC rule generation for CRD access

## Test plan
- [ ] external-dns-unifi-crd pod starts without RBAC errors
- [ ] DNSEndpoint resources are processed