### PR TITLE
fix(traefik): remove ignoreDifferences blocking TLS config update

### DIFF
--- a/charts/addons/templates/traefik.yaml
+++ b/charts/addons/templates/traefik.yaml
@@ -151,12 +151,6 @@ spec:
       kind: ValidatingWebhookConfiguration
       jqPathExpressions:
         - .webhooks[].clientConfig.caBundle
-    # Ignore traefik-dashboard IngressRoute spec entirely (dynamically managed by Traefik)
-    - group: traefik.io
-      kind: IngressRoute
-      name: traefik-dashboard
-      jqPathExpressions:
-        - .spec
 ---
 # DNSEndpoint for external-dns to create DNS record for Traefik dashboard
 # (Standard Ingress removed - was conflicting with IngressRoute from Traefik helm chart)


### PR DESCRIPTION
## Summary
The IngressRoute ignoreDifferences rule was preventing ArgoCD from updating the traefik-dashboard IngressRoute with TLS configuration, causing the dashboard to use a self-signed certificate.

## Changes
- Removed `.spec` ignoreDifferences for traefik-dashboard IngressRoute
- Allows helm chart TLS settings (referencing cert-manager certificate) to be applied

## Test plan
- [ ] ArgoCD syncs traefik application
- [ ] IngressRoute gets updated with TLS secretName
- [ ] Dashboard uses valid Let's Encrypt certificate