### PR TITLE
fix(gitops): add SkipDryRunOnMissingResource for CRD ordering

### DIFF
--- a/charts/gitops/values-homelab.yaml
+++ b/charts/gitops/values-homelab.yaml
@@ -48,6 +48,7 @@ addons:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
## Summary
- Add `SkipDryRunOnMissingResource=true` to addons syncOptions
- Fixes sync failure when CronWorkflow is applied before Argo Workflows CRDs exist

## Root Cause
The CronWorkflow (sync wave 9) was failing because Argo Workflows Application (sync wave 7) hadn't finished deploying its CRDs yet. ArgoCD's dry-run validation fails when CRDs don't exist.

## Test plan
- [ ] Addons application syncs successfully
- [ ] CronWorkflow is created after Argo Workflows deploys