### PR TITLE
fix(sync-waves): reorder cert-manager before traefik

### DIFF
--- a/charts/addons/templates/cert-manager.yaml
+++ b/charts/addons/templates/cert-manager.yaml
@@ -19,7 +19,8 @@ metadata:
   name: cert-manager
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    # Sync wave 0: cert-manager must deploy before ClusterIssuer (wave 1) and other resources needing TLS
+    argocd.argoproj.io/sync-wave: "0"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -74,13 +75,13 @@ spec:
 {{- if (index .Values "cert-manager" "letsencrypt" "enabled") }}
 ---
 # Let's Encrypt ClusterIssuer with Cloudflare DNS-01 challenge
-# Sync wave 2: After cert-manager (wave 1) is healthy, but before services needing TLS
+# Sync wave 1: After cert-manager (wave 0) is healthy, but before services needing TLS (wave 2+)
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   acme:
     server: {{ index .Values "cert-manager" "letsencrypt" "server" }}

--- a/charts/addons/templates/traefik.yaml
+++ b/charts/addons/templates/traefik.yaml
@@ -27,7 +27,8 @@ metadata:
   name: traefik
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    # Sync wave 2: After cert-manager (wave 0) and ClusterIssuer (wave 1) are ready
+    argocd.argoproj.io/sync-wave: "2"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
## Summary
- cert-manager Application: wave 0 (was 1)
- ClusterIssuer: wave 1 (was 2)  
- traefik Application: wave 2 (was 1)

## Root Cause
cert-manager and traefik were both at sync wave 1, causing race conditions where traefik resources needing cert-manager CRDs/ClusterIssuer could fail.

## Test plan
- [ ] cert-manager deploys and becomes healthy first
- [ ] ClusterIssuer creates successfully
- [ ] traefik deploys after cert-manager is ready