### PR TITLE
fix(traefik): use URN syntax for OIDC plugin secrets

### DIFF
--- a/charts/addons/templates/traefik.yaml
+++ b/charts/addons/templates/traefik.yaml
@@ -274,11 +274,11 @@ spec:
   plugin:
     traefikoidc:
       ProviderURL: {{ .Values.traefik.oidc.providerURL | quote }}
-      ClientID: file:///etc/traefik/oidc/google/client_id
-      ClientSecret: file:///etc/traefik/oidc/google/client_secret
+      ClientID: "urn:k8s:secret:google-oauth-credentials:client_id"
+      ClientSecret: "urn:k8s:secret:google-oauth-credentials:client_secret"
       CallbackURL: {{ .Values.traefik.oidc.callbackURL | quote }}
       LogoutURL: {{ .Values.traefik.oidc.logoutURL | quote }}
-      SessionEncryptionKey: file:///etc/traefik/oidc/session/session_key
+      SessionEncryptionKey: "urn:k8s:secret:oidc-session-key:oidc-session-key"
       Scopes:
         {{- toYaml .Values.traefik.oidc.scopes | nindent 8 }}
       AllowedUserDomains:


### PR DESCRIPTION
## Summary
- Fix traefikoidc plugin secret configuration to use `urn:k8s:secret:<name>:<key>` format
- The plugin doesn't support `file://` URIs - was passing literal path as client_id to Google OAuth

## Test plan
- [x] Verified `curl -sI https://workflows.ryanmcafee.com` shows correct Google OAuth client_id
- [x] Confirmed redirect_uri points to `https://auth.ryanmcafee.com/oauth2/callback`
- [x] Pre-commit hooks pass