### PR TITLE
fix(plex): use correct ingress url field for Plex Helm chart

### DIFF
--- a/charts/applications/values.yaml
+++ b/charts/applications/values.yaml
@@ -119,17 +119,14 @@ plex:
       readOnly: false
 
   # Ingress configuration
+  # Note: Plex chart uses 'url' field instead of 'hosts' array
   ingress:
     enabled: true
     ingressClassName: traefik
+    url: "https://plex.ryanmcafee.com"
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
       external-dns.alpha.kubernetes.io/hostname: plex.ryanmcafee.com
-    hosts:
-      - host: plex.ryanmcafee.com
-        paths:
-          - path: /
-            pathType: Prefix
     tls:
       - secretName: plex-tls
         hosts:


### PR DESCRIPTION
## Summary
- Fix Plex ingress configuration to use `url` field instead of `hosts` array
- The official Plex Helm chart expects `ingress.url` (single string), not the standard Kubernetes ingress structure

## Changes
The Plex chart template extracts hostname via `trimPrefix "https://"` from the `url` field.

## Test plan
- [x] Helm lint passes
- [x] Helm template renders correctly with `url` field
- [x] Pre-commit hooks pass