### PR TITLE
feat(argocd): disable auto-sync and self-healing for all applications

### DIFF
--- a/charts/addons/templates/1password-operator.yaml
+++ b/charts/addons/templates/1password-operator.yaml
@@ -41,9 +41,7 @@ spec:
     namespace: {{ index .Values "1password-operator" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/argo-workflows.yaml
+++ b/charts/addons/templates/argo-workflows.yaml
@@ -208,10 +208,7 @@ spec:
     namespace: {{ index .Values "argo-workflows" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/argocd.yaml
+++ b/charts/addons/templates/argocd.yaml
@@ -30,10 +30,7 @@ spec:
     namespace: {{ .Values.argocd.namespace | default "argocd" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/cert-manager.yaml
+++ b/charts/addons/templates/cert-manager.yaml
@@ -55,9 +55,7 @@ spec:
     namespace: {{ index .Values "cert-manager" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/cloudnative-pg.yaml
+++ b/charts/addons/templates/cloudnative-pg.yaml
@@ -34,9 +34,7 @@ spec:
     namespace: {{ index .Values "cloudnative-pg" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/democratic-csi.yaml
+++ b/charts/addons/templates/democratic-csi.yaml
@@ -115,9 +115,7 @@ spec:
     namespace: {{ index .Values "democratic-csi" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - ServerSideApply=true
       - ApplyOutOfSyncOnly=true

--- a/charts/addons/templates/external-dns-cloudflare.yaml
+++ b/charts/addons/templates/external-dns-cloudflare.yaml
@@ -74,9 +74,7 @@ spec:
     namespace: {{ index .Values "external-dns" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/external-dns-unifi.yaml
+++ b/charts/addons/templates/external-dns-unifi.yaml
@@ -132,9 +132,7 @@ spec:
     namespace: {{ index .Values "external-dns-unifi" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
@@ -220,9 +218,7 @@ spec:
     namespace: {{ index .Values "external-dns-unifi" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/kube-prometheus-stack.yaml
+++ b/charts/addons/templates/kube-prometheus-stack.yaml
@@ -113,9 +113,7 @@ spec:
     namespace: {{ index .Values "kube-prometheus-stack" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/kubelet-csr-approver.yaml
+++ b/charts/addons/templates/kubelet-csr-approver.yaml
@@ -39,9 +39,7 @@ spec:
     namespace: {{ index .Values "kubelet-csr-approver" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/local-path-provisioner.yaml
+++ b/charts/addons/templates/local-path-provisioner.yaml
@@ -30,9 +30,7 @@ spec:
     namespace: {{ index .Values "local-path-provisioner" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/nvidia-gpu-operator.yaml
+++ b/charts/addons/templates/nvidia-gpu-operator.yaml
@@ -140,9 +140,7 @@ spec:
     namespace: {{ index .Values "nvidia-gpu-operator" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/oauth2-proxy.yaml
+++ b/charts/addons/templates/oauth2-proxy.yaml
@@ -106,9 +106,7 @@ spec:
     namespace: {{ index .Values "oauth2-proxy" "namespace" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/sops-secrets.yaml
+++ b/charts/addons/templates/sops-secrets.yaml
@@ -114,9 +114,7 @@ spec:
     server: https://kubernetes.default.svc
     namespace: onepassword-operator
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/traefik.yaml
+++ b/charts/addons/templates/traefik.yaml
@@ -164,9 +164,7 @@ spec:
     namespace: {{ .Values.traefik.namespace }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/addons/templates/unifi-port-forward.yaml
+++ b/charts/addons/templates/unifi-port-forward.yaml
@@ -60,9 +60,7 @@ spec:
     server: https://kubernetes.default.svc
     namespace: {{ $namespace }}
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/applications/templates/argocd.yaml
+++ b/charts/applications/templates/argocd.yaml
@@ -30,10 +30,7 @@ spec:
     namespace: {{ .Values.argocd.namespace | default "argocd" }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/applications/templates/homeassistant.yaml
+++ b/charts/applications/templates/homeassistant.yaml
@@ -72,9 +72,7 @@ spec:
         - /spec/template/spec/hostUsers
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/applications/templates/mosquitto.yaml
+++ b/charts/applications/templates/mosquitto.yaml
@@ -56,9 +56,7 @@ spec:
         - /spec/template/spec/hostUsers
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/applications/templates/plex.yaml
+++ b/charts/applications/templates/plex.yaml
@@ -67,9 +67,7 @@ spec:
     namespace: {{ .Values.plex.namespace }}
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/applications/templates/prowlarr.yaml
+++ b/charts/applications/templates/prowlarr.yaml
@@ -56,9 +56,7 @@ spec:
         - /spec/template/spec/hostUsers
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/applications/templates/radarr.yaml
+++ b/charts/applications/templates/radarr.yaml
@@ -56,9 +56,7 @@ spec:
         - /spec/template/spec/hostUsers
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/applications/templates/sonarr.yaml
+++ b/charts/applications/templates/sonarr.yaml
@@ -56,9 +56,7 @@ spec:
         - /spec/template/spec/hostUsers
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # Automatic sync disabled - manual sync only
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/gitops/values-homelab.yaml
+++ b/charts/gitops/values-homelab.yaml
@@ -41,10 +41,11 @@ addons:
     namespace: argocd
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
+    # Automatic sync disabled - manual sync only
+    # automated:
+    #   prune: true
+    #   selfHeal: true
+    #   allowEmpty: false
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
@@ -77,10 +78,11 @@ applications:
     namespace: argocd
 
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
+    # Automatic sync disabled - manual sync only
+    # automated:
+    #   prune: true
+    #   selfHeal: true
+    #   allowEmpty: false
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/charts/gitops/values.yaml
+++ b/charts/gitops/values.yaml
@@ -64,11 +64,11 @@ addons:
 
   # Sync policy
   syncPolicy:
-    # Automatically sync when changes detected
-    automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
+    # Automatic sync disabled - manual sync only
+    # automated:
+    #   prune: true
+    #   selfHeal: true
+    #   allowEmpty: false
 
     # Sync options
     syncOptions:
@@ -114,11 +114,11 @@ applications:
 
   # Sync policy
   syncPolicy:
-    # Automatically sync when changes detected
-    automated:
-      prune: true
-      selfHeal: true
-      allowEmpty: false
+    # Automatic sync disabled - manual sync only
+    # automated:
+    #   prune: true
+    #   selfHeal: true
+    #   allowEmpty: false
 
     # Sync options
     syncOptions:


### PR DESCRIPTION
## Summary
- Disables automated sync policy (`prune: true`, `selfHeal: true`) from all ArgoCD applications
- Enables manual sync-only mode for more control over when changes are applied
- Affects 25 files across gitops, addons, and applications charts

## Changes
- Updated `charts/gitops/values.yaml` and `values-homelab.yaml`
- Updated 16 addon templates
- Updated 7 application templates

## Test Plan
- [x] Helm lint passes for all charts
- [x] Pre-commit hooks pass
- [ ] Verify applications show as OutOfSync but don't auto-sync