### PR TITLE
fix(traefik): use path-based OIDC callback URLs

### DIFF
--- a/charts/addons/values-homelab.yaml
+++ b/charts/addons/values-homelab.yaml
@@ -655,8 +655,9 @@ traefik:
   oidc:
     enabled: true
     providerURL: "https://accounts.google.com"
-    callbackURL: "https://auth.ryanmcafee.com/oauth2/callback"
-    logoutURL: "https://auth.ryanmcafee.com/oauth2/logout"
+    # Use path format - plugin constructs full URL from request host
+    callbackURL: "/oauth2/callback"
+    logoutURL: "/oauth2/logout"
     scopes:
       - openid
       - profile


### PR DESCRIPTION
## Summary
- Change `callbackURL` and `logoutURL` from full URLs to path format (`/oauth2/callback`)
- Fixes authentication redirect loop where `prompt=consent` was being sent on every request
- Plugin now constructs full callback URL from the incoming request host

## Required Manual Steps
After merging, update Google Cloud Console OAuth client with new redirect URIs:
- `https://workflows.ryanmcafee.com/oauth2/callback`
- `https://argocd.ryanmcafee.com/oauth2/callback`
- Add any other domains using the OIDC middleware

## Test Plan
- [ ] Update Google Cloud Console OAuth redirect URIs
- [ ] Merge PR and wait for ArgoCD sync
- [ ] Visit https://workflows.ryanmcafee.com
- [ ] Verify auth completes without redirect loop