### PR TITLE
feat(ingress): enable OIDC authentication on all ingresses except Plex

### DIFF
--- a/charts/addons/values-homelab.yaml
+++ b/charts/addons/values-homelab.yaml
@@ -102,7 +102,7 @@ argocd:
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt
           external-dns.alpha.kubernetes.io/hostname: argocd.ryanmcafee.com
-          # OIDC authentication via Traefik plugin (replaces oauth2-proxy)
+          # OIDC authentication via Traefik plugin
           traefik.ingress.kubernetes.io/router.middlewares: traefik-oidc-auth@kubernetescrd
 
       # Resource limits
@@ -535,8 +535,8 @@ kube-prometheus-stack:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         external-dns.alpha.kubernetes.io/hostname: grafana.ryanmcafee.com
-        # OAuth2-Proxy authentication middleware (disabled for debugging)
-        # traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-oauth2-proxy-auth@kubernetescrd
+        # OIDC authentication via Traefik plugin
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-oidc-auth@kubernetescrd
       hosts:
         - grafana.ryanmcafee.com
       tls:

--- a/charts/applications/values-homelab.yaml
+++ b/charts/applications/values-homelab.yaml
@@ -175,8 +175,8 @@ sonarr:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         external-dns.alpha.kubernetes.io/hostname: sonarr.ryanmcafee.com
-        # OAuth2-Proxy authentication middleware (disabled for debugging)
-        # traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-oauth2-proxy-auth@kubernetescrd
+        # OIDC authentication via Traefik plugin
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-oidc-auth@kubernetescrd
       hosts:
         - host: sonarr.ryanmcafee.com
           paths:
@@ -242,8 +242,8 @@ radarr:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         external-dns.alpha.kubernetes.io/hostname: radarr.ryanmcafee.com
-        # OAuth2-Proxy authentication middleware (disabled for debugging)
-        # traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-oauth2-proxy-auth@kubernetescrd
+        # OIDC authentication via Traefik plugin
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-oidc-auth@kubernetescrd
       hosts:
         - host: radarr.ryanmcafee.com
           paths:
@@ -302,8 +302,8 @@ prowlarr:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         external-dns.alpha.kubernetes.io/hostname: prowlarr.ryanmcafee.com
-        # OAuth2-Proxy authentication middleware (disabled for debugging)
-        # traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-oauth2-proxy-auth@kubernetescrd
+        # OIDC authentication via Traefik plugin
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-oidc-auth@kubernetescrd
       hosts:
         - host: prowlarr.ryanmcafee.com
           paths:
@@ -366,8 +366,8 @@ homeassistant:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         external-dns.alpha.kubernetes.io/hostname: homeassistant.ryanmcafee.com
-        # OAuth2-Proxy authentication middleware (disabled for debugging)
-        # traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-oauth2-proxy-auth@kubernetescrd
+        # OIDC authentication via Traefik plugin
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-oidc-auth@kubernetescrd
       hosts:
         - host: homeassistant.ryanmcafee.com
           paths:
@@ -546,8 +546,8 @@ argocd:
           external-dns.alpha.kubernetes.io/hostname: argocd.ryanmcafee.com
           # Tell Traefik to use HTTP when connecting to backend (ArgoCD serves HTTP on 8080)
           traefik.ingress.kubernetes.io/service.serversscheme: http
-          # OAuth2-Proxy authentication middleware - temporarily disabled
-          # traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-oauth2-proxy-auth@kubernetescrd
+          # OIDC authentication via Traefik plugin
+          traefik.ingress.kubernetes.io/router.middlewares: traefik-oidc-auth@kubernetescrd
 
       # Resource limits
       resources:


### PR DESCRIPTION
## Summary
- Enable `traefik-oidc-auth@kubernetescrd` middleware on all ingresses
- Sonarr, Radarr, Prowlarr, Home Assistant, ArgoCD, and Grafana now require OIDC authentication
- Plex excluded (handles its own authentication via Plex account)

## Test plan
- [ ] Verify all protected ingresses redirect to Google OIDC login
- [ ] Verify Plex remains accessible without OIDC redirect
- [ ] Confirm authenticated users can access protected services