### PR TITLE
fix(argocd): raise controller memory to 1Gi/2Gi to stop OOMKills

### DIFF
--- a/charts/bootstrap/values-homelab.yaml
+++ b/charts/bootstrap/values-homelab.yaml
@@ -58,13 +58,18 @@ argocd:
           memory: 512Mi
 
     controller:
+      # Bumped from 512Mi/1Gi after argocd-application-controller-0 was OOMKilled
+      # 11 times (exit code 137). Homelab fleet sits ~30 ArgoCD Applications and
+      # the controller's working set needs ~1Gi steady-state, spiking higher
+      # during sync storms. Upstream base is 2Gi/4Gi; 1Gi/2Gi is a middle ground
+      # sized for this cluster's load.
       resources:
         requests:
           cpu: 250m
-          memory: 512Mi
+          memory: 1Gi
         limits:
           cpu: 1000m
-          memory: 1Gi
+          memory: 2Gi
 
     repoServer:
       # HA configuration - 2 replicas spread across different hosts


### PR DESCRIPTION
## Summary

- Bump `argocd.controller.resources` in `charts/bootstrap/values-homelab.yaml` from `512Mi/1Gi` → `1Gi/2Gi`.
- The homelab override was roughly half of what the controller actually needs for ~30 ArgoCD Applications on this cluster, and it has been OOMKilled 11 times (`exit code 137`, `reason: OOMKilled`).

## Why

Live pod state on main before this change:
```
argocd-application-controller-0
  restarts=11
  lastState={"terminated":{"exitCode":137,"reason":"OOMKilled"}}
  requests={cpu: 250m, memory: 512Mi}
  limits={cpu: 1000m, memory: 1Gi}
```

Upstream chart default is `2Gi / 4Gi`. The old homelab override was half of that. 1Gi/2Gi is a middle ground — enough headroom for sync storms without reserving 4Gi on a worker.

## Test plan

- [ ] CI green
- [ ] After merge, `bootstrap` ArgoCD app picks up the new values (auto-sync) and rolls the `argocd-application-controller` StatefulSet
- [ ] New pod's resources reflect `requests: {memory: 1Gi}` / `limits: {memory: 2Gi}`
- [ ] Restart count stops climbing

## Self-managed caveat

ArgoCD is managing itself via the `bootstrap` app. When the controller rolls, the controller doing the sync is the same pod being replaced — brief sync gap (~10–30s) while the StatefulSet rotates. In-flight app syncs resume automatically after the new pod reconciles.