### PR TITLE
fix(argo-workflows): use schedules array for CronWorkflow in v3.6+

### DIFF
--- a/charts/argo-workflows-config/templates/cronworkflow.yaml
+++ b/charts/argo-workflows-config/templates/cronworkflow.yaml
@@ -5,7 +5,11 @@ metadata:
   name: ingress-verification
   namespace: {{ .Values.namespace }}
 spec:
-  schedule: {{ .Values.ingressVerification.schedule | quote }}
+  # CronWorkflow schema in Argo Workflows v3.6+ renamed `schedule` (string) to
+  # `schedules` (array) for multi-cron support. Keep the values key singular so
+  # env overrides stay simple; wrap it into the array here.
+  schedules:
+    - {{ .Values.ingressVerification.schedule | quote }}
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2


### PR DESCRIPTION
## Summary

Fix the `argo-workflows-config` ArgoCD sync failure on PR/main by migrating `CronWorkflow.spec.schedule` (string) → `CronWorkflow.spec.schedules` (array) for Argo Workflows v3.6+.

## Why

Argo Workflows v3.6 restructured the `CronWorkflow` CRD to support multiple cron schedules per workflow. The old `.spec.schedule` (string) field was removed; the new schema only has `.spec.schedules` (array of strings).

Live CRD confirms:

```
$ kubectl get crd cronworkflows.argoproj.io -o jsonpath='{.spec.versions[*].schema.openAPIV3Schema.properties.spec.properties}'
# properties: concurrencyPolicy, failedJobsHistoryLimit, schedules, startingDeadlineSeconds,
#             stopStrategy, successfulJobsHistoryLimit, suspend, timezone, when, workflowMetadata, workflowSpec
# (note: 'schedule' NOT in list)
```

ArgoCD sync error on `argo-workflows-config`:

```
failed to create typed patch object (argo-workflows/ingress-verification;
argoproj.io/v1alpha1, Kind=CronWorkflow): .spec.schedule: field not declared in schema
```

## Change

Wrap the existing values-provided expression in a single-element `schedules` array. Keep the values key itself singular (`ingressVerification.schedule`) so environment overrides stay simple.

```diff
-  schedule: {{ .Values.ingressVerification.schedule | quote }}
+  schedules:
+    - {{ .Values.ingressVerification.schedule | quote }}
```

## Test plan

- [ ] CI green (helm lint, yaml lint, tilt ci)
- [ ] After merge, `argo-workflows-config` ArgoCD app re-sync succeeds
- [ ] `CronWorkflow/ingress-verification` resource in `argo-workflows` ns has `.spec.schedules: ["0 0 * * *"]` (homelab value)
- [ ] Next scheduled run fires at the configured time