### PR TITLE
fix(nfd): mark node-feature-discovery namespace as privileged PodSecurity

### DIFF
--- a/charts/addons/templates/node-feature-discovery.yaml
+++ b/charts/addons/templates/node-feature-discovery.yaml
@@ -1,10 +1,21 @@
 {{- if index .Values "node-feature-discovery" "enabled" }}
 ---
-# Namespace for NodeFeatureDiscovery components
+# Namespace for NodeFeatureDiscovery components.
+#
+# Requires privileged PodSecurity because the nfd-worker DaemonSet mounts
+# host paths for hardware discovery: /boot, /etc/os-release, /sys, /usr/lib,
+# /lib, /proc/swaps, and /etc/kubernetes/node-feature-discovery/features.d.
+# Without these labels the baseline PodSecurity cluster default rejects the
+# DaemonSet pods with:
+#   violates PodSecurity "baseline:latest": hostPath volumes
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ index .Values "node-feature-discovery" "namespace" }}
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   annotations:
     argocd.argoproj.io/sync-wave: "9"
 ---


### PR DESCRIPTION
## Summary

Label the `node-feature-discovery` namespace with `pod-security.kubernetes.io/{enforce,audit,warn}=privileged` so the nfd-worker DaemonSet can be admitted. Mirrors the existing `intel-gpu-device-plugin` namespace pattern.

## Why

After PR #226 landed and the NFD Application started syncing, the nfd-worker DaemonSet failed to create pods:

\`\`\`
pods "node-feature-discovery-worker-c6fns" is forbidden:
  violates PodSecurity "baseline:latest": hostPath volumes
  (volumes "host-boot", "host-os-release", "host-sys",
   "host-usr-lib", "host-lib", "host-proc-swaps", "features-d")
\`\`\`

NFD's worker needs hostPath mounts by design — it reads `/boot`, `/etc/os-release`, `/sys`, `/usr/lib`, `/lib`, `/proc/swaps`, and `/etc/kubernetes/node-feature-discovery/features.d` to discover node features (CPU flags, kernel modules, PCI devices, etc.). `baseline` PodSecurity disallows hostPath, so the namespace needs `privileged`.

The same pattern is already in place for `intel-gpu-device-plugin` (namespace template at `charts/addons/templates/intel-gpu-device-plugin.yaml:6-12`) and is the correct fix for trusted infrastructure DaemonSets.

## Test plan

- [ ] CI green
- [ ] After merge + ArgoCD sync, `kubectl -n node-feature-discovery get pods` shows nfd-master Running and nfd-worker DaemonSet 6/6 Ready
- [ ] `kubectl get node talos-lz1-3u1 -o json | jq '.metadata.labels'` includes `feature.node.kubernetes.io/pci-8086.present: "true"`
- [ ] Unblocks the intel-gpu-device-plugin rollout and the downstream Plex GPU wiring from PR #226's plan