### PR TITLE
fix(gpu): unblock Plex Intel GPU pipeline — operator chart + dedupe dev-dri

### DIFF
--- a/charts/addons/templates/intel-device-plugins-operator.yaml
+++ b/charts/addons/templates/intel-device-plugins-operator.yaml
@@ -1,0 +1,60 @@
+{{- if index .Values "intel-device-plugins-operator" "enabled" }}
+---
+# Namespace for Intel Device Plugins Operator
+# Installs the operator controller and the GpuDevicePlugin/NodeFeatureRule CRDs
+# that the intel-gpu-device-plugin chart (wave 10) depends on. Without this,
+# the intel-gpu-device-plugin sync fails with:
+#   "The Kubernetes API could not find deviceplugin.intel.com/GpuDevicePlugin
+#    ... Make sure the \"GpuDevicePlugin\" CRD is installed on the destination cluster."
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "intel-device-plugins-operator" "namespace" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "9"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: intel-device-plugins-operator
+  namespace: argocd
+  annotations:
+    # Wave 9: before the intel-gpu-device-plugin chart at wave 10. The operator
+    # installs the deviceplugin.intel.com CRDs the plugin chart's CRs reference.
+    argocd.argoproj.io/sync-wave: "9"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: {{ index .Values "intel-device-plugins-operator" "chart" "repo" }}
+    chart: {{ index .Values "intel-device-plugins-operator" "chart" "name" }}
+    targetRevision: {{ index .Values "intel-device-plugins-operator" "chart" "version" }}
+    helm:
+      releaseName: intel-device-plugins-operator
+      values: |
+        # Install CRDs for GpuDevicePlugin (and other device plugin CRs)
+        manager:
+          devices:
+            gpu: true
+            # Disable plugins we don't use — keeps the operator scope minimal
+            dlb: false
+            dsa: false
+            fpga: false
+            iaa: false
+            qat: false
+            sgx: false
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ index .Values "intel-device-plugins-operator" "namespace" }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - ApplyOutOfSyncOnly=true
+{{- end }}

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -884,6 +884,22 @@ intel-gpu-device-plugin:
     version: "0.35.0"
 
 # ============================================================================
+# Intel Device Plugins Operator - installs the GpuDevicePlugin CRD and a
+# reconciler that turns GpuDevicePlugin CRs (created by intel-gpu-device-plugin
+# at wave 10) into live DaemonSets. Required prerequisite — without it the
+# plugin chart fails with "GpuDevicePlugin CRD not installed".
+# ============================================================================
+
+intel-device-plugins-operator:
+  enabled: false
+  namespace: intel-device-plugins
+
+  chart:
+    name: intel-device-plugins-operator
+    repo: https://intel.github.io/helm-charts
+    version: "0.35.0"
+
+# ============================================================================
 # NodeFeatureDiscovery - hardware feature labeling
 # Required prerequisite for intel-gpu-device-plugin. Also broadly useful for
 # any chart with PCI/CPU/kernel-feature-driven nodeSelectors. Runs as a

--- a/configuration/templates/helm-addons.tmpl
+++ b/configuration/templates/helm-addons.tmpl
@@ -974,6 +974,21 @@ intel-gpu-device-plugin:
     version: "{{ index .Versions.Charts "intel-device-plugins-gpu" }}"
 
 # ============================================================================
+# Intel Device Plugins Operator - installs CRDs + reconciler for GpuDevicePlugin
+# Sync Wave: 9 (before the intel-gpu-device-plugin chart at wave 10)
+# Gated on GPU_VENDOR=intel — operator only matters when the Intel plugin is on.
+# ============================================================================
+
+intel-device-plugins-operator:
+  enabled: {{ eq .Values.GPU_VENDOR.Value "intel" }}
+  namespace: intel-device-plugins
+
+  chart:
+    name: intel-device-plugins-operator
+    repo: https://intel.github.io/helm-charts
+    version: "{{ index .Versions.Charts "intel-device-plugins-operator" }}"
+
+# ============================================================================
 # NodeFeatureDiscovery - hardware feature labeling
 # Sync Wave: 9 (before intel-gpu-device-plugin / nvidia-gpu-operator at wave 10)
 # Always enabled regardless of GPU_VENDOR — it is a general-purpose label source

--- a/configuration/templates/helm-apps.tmpl
+++ b/configuration/templates/helm-apps.tmpl
@@ -150,12 +150,11 @@ plex:
       nfs:
         server: {{ .Values.TRUENAS_HOSTNAME.Value }}
         path: {{ .Values.MEDIA_PICTURES_PATH.Value }}
-{{- if eq .Values.GPU_VENDOR.Value "intel" }}
-    - name: dev-dri
-      hostPath:
-        path: /dev/dri
-        type: Directory
-{{- end }}
+  # NOTE: dev-dri volume + mount for Intel GPU is added by the Plex application
+  # chart template (charts/applications/templates/plex.yaml) based on
+  # .Values.plex.gpu.vendor == "intel". Don't append it here, or the structured-
+  # merge diff against the rendered StatefulSet fails with "duplicate entries
+  # for key [name=\"dev-dri\"]".
 
   extraVolumeMounts:
     - name: movies
@@ -170,10 +169,7 @@ plex:
     - name: pictures
       mountPath: /pictures
       readOnly: false
-{{- if eq .Values.GPU_VENDOR.Value "intel" }}
-    - name: dev-dri
-      mountPath: /dev/dri
-{{- end }}
+  # (dev-dri mount is also added by plex.yaml — see note above.)
 
   # Ingress configuration
   ingress:

--- a/configuration/versions.yaml
+++ b/configuration/versions.yaml
@@ -55,6 +55,8 @@ charts:
   nvidia-gpu-operator: "v26.3.0"
   # renovate: datasource=helm depName=intel-device-plugins-gpu registryUrl=https://intel.github.io/helm-charts
   intel-device-plugins-gpu: "0.35.0"
+  # renovate: datasource=helm depName=intel-device-plugins-operator registryUrl=https://intel.github.io/helm-charts
+  intel-device-plugins-operator: "0.35.0"
   # renovate: datasource=helm depName=node-feature-discovery registryUrl=https://kubernetes-sigs.github.io/node-feature-discovery/charts
   node-feature-discovery: "0.18.0"
   # renovate: datasource=helm depName=oauth2-proxy registryUrl=https://oauth2-proxy.github.io/manifests


### PR DESCRIPTION
## Summary

Two blockers preventing the Plex Intel GPU pipeline from coming online after PRs #226 / #227 landed NFD. Fixed together since they're on the same critical path.

### Blocker 1: Missing `GpuDevicePlugin` CRD

\`intel-gpu-device-plugin\` sync failed:

\`\`\`
The Kubernetes API could not find deviceplugin.intel.com/GpuDevicePlugin
for requested resource intel-device-plugins/gpudeviceplugin-sample.
Make sure the "GpuDevicePlugin" CRD is installed on the destination cluster.
\`\`\`

The \`intel-device-plugins-gpu\` chart creates a \`GpuDevicePlugin\` CR but relies on a sibling chart (\`intel-device-plugins-operator\`) to install the CRD and ship a reconciler that turns \`GpuDevicePlugin\` CRs into DaemonSets.

**Fix:** new \`charts/addons/templates/intel-device-plugins-operator.yaml\` (mirrors the intel-gpu-device-plugin template pattern), gated on \`GPU_VENDOR=intel\`, sync wave 9 (same wave as NFD, one wave before the plugin at wave 10). Minimal operator values: only the \`gpu\` manager is enabled — \`dlb/dsa/fpga/iaa/qat/sgx\` are explicitly disabled to keep scope minimal.

### Blocker 2: Duplicate \`dev-dri\` in Plex helm.values

\`plex\` app sync failed:

\`\`\`
.spec.template.spec.volumes: duplicate entries for key [name="dev-dri"]
.spec.template.spec.containers[name="plex-plex-media-server-pms"].volumeMounts:
  duplicate entries for key [mountPath="/dev/dri"]
\`\`\`

Both \`configuration/templates/helm-apps.tmpl\` AND \`charts/applications/templates/plex.yaml\` were appending a \`dev-dri\` entry when \`GPU_VENDOR=intel\`. The chart template's conditional is the correct abstraction (reads \`.Values.plex.gpu.vendor\`, pulls hostPath from \`.Values.plex.gpu.intel.devDri.hostPath\`).

**Fix:** remove the redundant append from helm-apps.tmpl. Values flow is now: \`plex.gpu.vendor=intel\` is set in helm-apps.tmpl → \`plex.yaml\` chart conditional emits exactly one \`dev-dri\` volume + volumeMount.

## Test plan

- [ ] CI green
- [ ] After merge + ArgoCD sync:
  - \`kubectl get crd gpudeviceplugins.deviceplugin.intel.com\` → exists
  - \`kubectl -n intel-device-plugins get pods\` → operator + plugin DaemonSet Running
  - \`kubectl get node talos-lz1-3u1 -o json | jq '.status.allocatable'\` → contains \`gpu.intel.com/xe: "1"\`
  - \`kubectl -n argocd get app plex -o jsonpath='{.status.sync.status}'\` → Synced (no more ComparisonError)
  - \`kubectl -n media get pod plex-plex-media-server-0 -o json | jq '[.spec.volumes[] | select(.name=="dev-dri")]'\` → array of exactly one entry
  - \`kubectl -n media exec plex-plex-media-server-0 -- ls /dev/dri\` → \`card0 renderD128\`

## Context

This is the 4th PR in the Plex Intel GPU work — #226 (NFD), #227 (NFD privileged ns), now #228 (operator + dev-dri). The end state is hardware transcoding for Plex on worker-1 via the Intel Arc Pro B50.