### PR TITLE
fix(gpu): NFD long-form PCI labels + dedupe intel-device-plugins namespace

### DIFF
--- a/charts/addons/templates/intel-device-plugins-operator.yaml
+++ b/charts/addons/templates/intel-device-plugins-operator.yaml
@@ -1,15 +1,22 @@
 {{- if index .Values "intel-device-plugins-operator" "enabled" }}
 ---
-# Namespace for Intel Device Plugins Operator
-# Installs the operator controller and the GpuDevicePlugin/NodeFeatureRule CRDs
-# that the intel-gpu-device-plugin chart (wave 10) depends on. Without this,
-# the intel-gpu-device-plugin sync fails with:
-#   "The Kubernetes API could not find deviceplugin.intel.com/GpuDevicePlugin
-#    ... Make sure the \"GpuDevicePlugin\" CRD is installed on the destination cluster."
+# Shared namespace for the Intel Device Plugins operator AND the
+# intel-gpu-device-plugin. Owned by the operator template (this file) because
+# the operator syncs at wave 9, one wave before the plugin at wave 10. The
+# plugin template intentionally does NOT declare this Namespace — declaring it
+# in both produces a "RepeatedResourceWarning" on the addons app and makes
+# ArgoCD's sync engine fight over the labels.
+#
+# Privileged PodSecurity is required because the GPU device plugin DaemonSet
+# mounts /dev/dri (a hostPath device) — baseline rejects it.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ index .Values "intel-device-plugins-operator" "namespace" }}
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   annotations:
     argocd.argoproj.io/sync-wave: "9"
 ---

--- a/charts/addons/templates/intel-gpu-device-plugin.yaml
+++ b/charts/addons/templates/intel-gpu-device-plugin.yaml
@@ -1,18 +1,8 @@
 {{- if index .Values "intel-gpu-device-plugin" "enabled" }}
 ---
-# Namespace for Intel GPU device plugin components
-# Requires privileged PodSecurity for GPU device access (/dev/dri)
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ index .Values "intel-gpu-device-plugin" "namespace" }}
-  labels:
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/warn: privileged
-  annotations:
-    argocd.argoproj.io/sync-wave: "10"
----
+# NOTE: the intel-device-plugins Namespace is owned by
+# charts/addons/templates/intel-device-plugins-operator.yaml (sync wave 9).
+# Declaring it here too produces a RepeatedResourceWarning on the addons app.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/applications/values.yaml
+++ b/charts/applications/values.yaml
@@ -81,15 +81,19 @@ plex:
     vendor: "none"
 
     # NVIDIA GPU settings (Quadro P2200)
+    # NFD's default PCI label format is pci-<class>_<vendor>.present where 0300
+    # is the PCI class code for "Display controller" and 10de is NVIDIA's vendor
+    # ID. The short pci-10de.present form is NOT emitted by NFD's default
+    # source config — using it as a nodeSelector would leave the pod Pending.
     nvidia:
       runtimeClassName: nvidia
       nodeSelector:
-        feature.node.kubernetes.io/pci-10de.present: "true"
+        feature.node.kubernetes.io/pci-0300_10de.present: "true"
 
-    # Intel GPU settings (Arc Pro B50)
+    # Intel GPU settings (Arc Pro B50). Same NFD long-form rationale — see above.
     intel:
       nodeSelector:
-        feature.node.kubernetes.io/pci-8086.present: "true"
+        feature.node.kubernetes.io/pci-0300_8086.present: "true"
       resources:
         limits:
           gpu.intel.com/xe: 1

--- a/configuration/templates/helm-apps.tmpl
+++ b/configuration/templates/helm-apps.tmpl
@@ -64,14 +64,22 @@ plex:
   # GPU configuration (NVIDIA Quadro P2200)
   runtimeClassName: nvidia  # For GPU transcoding
 
-  # Node selector for GPU-enabled nodes
+  # Node selector for GPU-enabled nodes.
+  # NFD's default PCI label format is pci-<class>_<vendor>.present where 0300
+  # is the PCI class code for "Display controller" and 10de is NVIDIA's vendor
+  # ID. Using the short pci-10de.present form would never match because NFD
+  # only emits the long form.
   nodeSelector:
-    feature.node.kubernetes.io/pci-10de.present: "true"
+    feature.node.kubernetes.io/pci-0300_10de.present: "true"
 {{- else if eq .Values.GPU_VENDOR.Value "intel" }}
 
-  # Node selector for GPU-enabled nodes
+  # Node selector for GPU-enabled nodes.
+  # NFD's default PCI label format is pci-<class>_<vendor>.present where 0300
+  # is the PCI class code for "Display controller" and 8086 is Intel's vendor
+  # ID. Using the short pci-8086.present form would never match because NFD
+  # only emits the long form.
   nodeSelector:
-    feature.node.kubernetes.io/pci-8086.present: "true"
+    feature.node.kubernetes.io/pci-0300_8086.present: "true"
 {{- end }}
 
   # GPU vendor selection (from GPU_VENDOR config flag)

--- a/tests/fixtures/toggle-baseline/nvidia/applications.yaml
+++ b/tests/fixtures/toggle-baseline/nvidia/applications.yaml
@@ -728,7 +728,7 @@ spec:
           TZ: America/New_York
         runtimeClassName: nvidia
         nodeSelector:
-          feature.node.kubernetes.io/pci-10de.present: "true"
+          feature.node.kubernetes.io/pci-0300_10de.present: "true"
         pms:
           claimSecret:
             key: plex-claim-token


### PR DESCRIPTION
## Summary

Two follow-up fixes after PR #228 (operator chart + dev-dri dedupe) merged. Both block the cascade from completing.

### 1. NFD long-form PCI labels for Plex nodeSelector

NFD's default PCI source emits \`feature.node.kubernetes.io/pci-<class>_<vendor>.present\` where class is the PCI device class (\`0300\` = "Display controller") and vendor is the PCI vendor ID (\`8086\` = Intel, \`10de\` = NVIDIA). The vendor-only short form (\`pci-8086.present\`, \`pci-10de.present\`) is **not** emitted by NFD's defaults — using it as a nodeSelector leaves the GPU pod \`Pending\` forever.

Verified live on \`talos-lz1-3u1\` (Intel B50 worker) after PR #226 NFD landed:

\`\`\`json
{
  "feature.node.kubernetes.io/pci-0300_1af4.present": "true",
  "feature.node.kubernetes.io/pci-0300_8086.present": "true"
}
\`\`\`

Switch the Plex chart's Intel and NVIDIA nodeSelectors to the long form so the pod actually schedules onto the GPU node. Updated:

- \`configuration/templates/helm-apps.tmpl\` — CMP-rendered values
- \`charts/applications/values.yaml\` — chart defaults for \`plex.gpu.{nvidia,intel}.nodeSelector\`
- \`tests/fixtures/toggle-baseline/nvidia/applications.yaml\` — regenerated baseline so \`task gpu:toggle-test\` stays green

### 2. Dedupe the \`intel-device-plugins\` Namespace declaration

ArgoCD addons app surfaced after PR #228 merged:

\`\`\`
RepeatedResourceWarning:
Resource /Namespace//intel-device-plugins appeared 2 times among application resources.
\`\`\`

Both \`intel-device-plugins-operator.yaml\` (added in #228) and the existing \`intel-gpu-device-plugin.yaml\` declared the same Namespace. Move ownership to the operator template (it syncs at wave 9, before the plugin at wave 10) — including the privileged PodSecurity labels so the plugin DaemonSet can still mount \`/dev/dri\`. Remove the Namespace block from the plugin template.

## Out of scope

Talos \`nodeLabels\` patches and the \`terragrunt.hcl\` \`gpu_*_config_patch\` entries still reference the short form \`pci-8086.present\` / \`pci-10de.present\`. They're dead code paths today (NodeRestriction blocks Talos' worker-side NodeApplyController from setting labels outside the kubelet allowlist), so they don't break anything. Cleanup can ride a separate PR.

## Test plan

- [ ] CI green
- [ ] After merge:
  - \`kubectl -n argocd get app addons -o jsonpath='{.status.conditions}'\` → no \`RepeatedResourceWarning\`
  - \`kubectl -n media get pod plex-plex-media-server-0 -o jsonpath='{.spec.nodeSelector}'\` → contains \`feature.node.kubernetes.io/pci-0300_8086.present: "true"\`
  - Plex pod schedules on \`talos-lz1-3u1\`, no longer Pending
  - \`kubectl -n media exec plex-plex-media-server-0 -- ls /dev/dri\` → \`card0 renderD128\`