### PR TITLE
fix(media): privilege media ns + intel.feature.node label for Plex + nzbget args

### DIFF
--- a/charts/applications/templates/namespaces.yaml
+++ b/charts/applications/templates/namespaces.yaml
@@ -1,10 +1,22 @@
 ---
 # Namespace: media
-# Created early so config charts and app deployments have a target namespace
+# Created early so config charts and app deployments have a target namespace.
+# Privileged PodSecurity is required because Plex hostPath-mounts /dev/dri for
+# Intel GPU hardware transcoding. The intel-gpu-device-plugin is not yet
+# advertising gpu.intel.com/xe in node allocatable on this Talos cluster (the
+# pod is Running but the plugin scans /dev/dri/by-path which Talos may populate
+# differently), so we work around it via direct hostPath instead of the device
+# plugin's resource-based device injection. Once the device plugin advertises
+# the resource, the hostPath can be removed AND this namespace can drop back to
+# baseline.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: media
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   annotations:
     argocd.argoproj.io/sync-wave: "10"
 ---

--- a/charts/applications/values.yaml
+++ b/charts/applications/values.yaml
@@ -90,13 +90,19 @@ plex:
       nodeSelector:
         feature.node.kubernetes.io/pci-0300_10de.present: "true"
 
-    # Intel GPU settings (Arc Pro B50). Same NFD long-form rationale — see above.
+    # Intel GPU settings (Arc Pro B50). Uses the Intel GPU device plugin's
+    # `intel-gpu-platform-labeling` NodeFeatureRule label, which is set only on
+    # nodes where the device plugin successfully identifies an Intel GPU. This
+    # is the canonical Intel-side convention (the GpuDevicePlugin CR uses the
+    # same label as its own nodeSelector).
     intel:
       nodeSelector:
-        feature.node.kubernetes.io/pci-0300_8086.present: "true"
-      resources:
-        limits:
-          gpu.intel.com/xe: 1
+        intel.feature.node.kubernetes.io/gpu: "true"
+      # gpu.intel.com/xe resource limit intentionally omitted — the device
+      # plugin DaemonSet is Running but is not advertising the resource yet
+      # on this Talos cluster. Plex gets /dev/dri via the hostPath mount
+      # below and uses the GPU directly via the xe driver. Re-add the limit
+      # once the plugin advertises the resource.
       devDri:
         hostPath: /dev/dri
 
@@ -474,6 +480,20 @@ nzbget:
       podSpec:
         containers:
           main:
+            # nzbget v26 made Paths.MainDir and Paths.ScriptDir REQUIRED, and
+            # the truecharts/forge image renamed the bundled 7-zip binary from
+            # /usr/bin/7za to /usr/bin/7z. The persisted /config/nzbget.conf
+            # in the existing PVC predates v26 and is missing all three —
+            # nzbget refuses to start. Override at startup via the documented
+            # `-o Section.Key=value` flags so we don't have to mutate the
+            # config file inside the PVC.
+            args:
+              - "-o"
+              - "Paths.MainDir=/downloads"
+              - "-o"
+              - "Paths.ScriptDir=/config/scripts"
+              - "-o"
+              - "Unpack.SevenZipCmd=/usr/bin/7z"
             resources:
               requests:
                 cpu: 100m

--- a/configuration/templates/helm-apps.tmpl
+++ b/configuration/templates/helm-apps.tmpl
@@ -73,13 +73,16 @@ plex:
     feature.node.kubernetes.io/pci-0300_10de.present: "true"
 {{- else if eq .Values.GPU_VENDOR.Value "intel" }}
 
-  # Node selector for GPU-enabled nodes.
-  # NFD's default PCI label format is pci-<class>_<vendor>.present where 0300
-  # is the PCI class code for "Display controller" and 8086 is Intel's vendor
-  # ID. Using the short pci-8086.present form would never match because NFD
-  # only emits the long form.
+  # Node selector for GPU-enabled nodes. The Intel GPU device plugin's
+  # `intel-gpu-platform-labeling` NodeFeatureRule sets
+  # `intel.feature.node.kubernetes.io/gpu=true` on every node where the plugin
+  # successfully identifies an Intel GPU — strictly better than the generic PCI
+  # vendor label because it confirms the device plugin actually recognized the
+  # GPU (not just that a PCI device with vendor 8086 exists). The
+  # GpuDevicePlugin CR uses this same label as its own nodeSelector, so Plex
+  # aligns with the canonical Intel-side convention.
   nodeSelector:
-    feature.node.kubernetes.io/pci-0300_8086.present: "true"
+    intel.feature.node.kubernetes.io/gpu: "true"
 {{- end }}
 
   # GPU vendor selection (from GPU_VENDOR config flag)
@@ -107,9 +110,14 @@ plex:
       limits:
         cpu: 4000m
         memory: 16Gi
-{{- if eq .Values.GPU_VENDOR.Value "intel" }}
-        gpu.intel.com/xe: 1
-{{- end }}
+    # NOTE: gpu.intel.com/xe resource limit intentionally NOT set yet.
+    # The intel-gpu-device-plugin DaemonSet is Running on talos-lz1-3u1 but is
+    # not advertising gpu.intel.com/xe in node allocatable (plugin logs cut off
+    # after "GPU (i915/xe) resource share count = 1" with no advertisement
+    # events; likely Talos /dev/dri/by-path layout incompatibility). Plex gets
+    # /dev/dri via the hostPath mount in plex.yaml's Intel branch and uses the
+    # GPU directly via the xe driver. Re-add the resource limit once the
+    # device plugin actually advertises the resource.
 
   # Persistence configuration
   persistence:
@@ -457,6 +465,20 @@ nzbget:
       podSpec:
         containers:
           main:
+            # nzbget v26 made Paths.MainDir and Paths.ScriptDir REQUIRED, and
+            # the truecharts/forge image renamed the bundled 7-zip binary from
+            # /usr/bin/7za to /usr/bin/7z. The persisted /config/nzbget.conf
+            # in the existing PVC predates v26 and is missing all three —
+            # nzbget refuses to start. Override at startup via the documented
+            # `-o Section.Key=value` flags so we don't have to mutate the
+            # config file inside the PVC.
+            args:
+              - "-o"
+              - "Paths.MainDir=/downloads"
+              - "-o"
+              - "Paths.ScriptDir=/config/scripts"
+              - "-o"
+              - "Unpack.SevenZipCmd=/usr/bin/7z"
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Summary

Three tightly-coupled fixes that together unblock the Plex Intel GPU pipeline and the nzbget CrashLoopBackOff in the same namespace.

### 1. Privilege the \`media\` namespace

Plex's StatefulSet has been failing to create pods after PR #228 wired the \`/dev/dri\` hostPath mount through:

\`\`\`
pods "plex-plex-media-server-0" is forbidden:
  violates PodSecurity "baseline:latest": hostPath volumes (volume "dev-dri")
\`\`\`

The \`media\` Namespace declaration had no PodSecurity labels and inherited the cluster default \`baseline\`, which forbids hostPath. Add the \`pod-security.kubernetes.io/{enforce,audit,warn}=privileged\` labels, mirroring the existing \`home-automation\` precedent in the same file.

### 2. Plex Intel branch nodeSelector → \`intel.feature.node.kubernetes.io/gpu=true\`

This is the canonical Intel-side label, set by the Intel GPU device plugin's \`intel-gpu-platform-labeling\` NodeFeatureRule on every node where the device plugin successfully identified an Intel GPU.

Verified live on \`talos-lz1-3u1\`:

\`\`\`json
{
  "intel.feature.node.kubernetes.io/gpu": "true",
  "gpu.intel.com/device-id.0300-e212.count": "1",
  "gpu.intel.com/device-id.0300-e212.present": "true"
}
\`\`\`

Strictly better than the generic \`feature.node.kubernetes.io/pci-0300_8086.present\` from PR #229: it confirms the device plugin actually recognized the GPU, not just that a PCI device with vendor 8086 happens to exist. The \`GpuDevicePlugin\` CR itself uses this same label as its own nodeSelector — Plex now aligns with the canonical convention.

NVIDIA branch left as-is (still uses \`pci-0300_10de.present\`) because the nvidia-gpu-operator's bundled NFD is currently disabled (PR #226's \`nfd.enabled=false\`) and there's no \`nvidia.feature.node.kubernetes.io/gpu\` equivalent. Dead code today anyway since \`GPU_VENDOR=intel\`.

### 3. Drop the \`gpu.intel.com/xe: 1\` resource limit

The intel-gpu-device-plugin DaemonSet is Running on \`talos-lz1-3u1\`, but it is **not** advertising \`gpu.intel.com/xe\` in node allocatable. Plugin logs cut off after \`"GPU (i915/xe) resource share count = 1"\` with no follow-up advertisement events — likely a Talos \`/dev/dri/by-path\` layout incompatibility (under investigation as a separate issue).

Keeping the resource limit would leave Plex permanently \`Unschedulable\`. Plex still gets \`/dev/dri\` via the hostPath mount and uses the GPU directly via the xe driver. Re-add the limit once the device plugin advertises the resource.

### 4. nzbget args override for v26 config validation

\`nzbget-584d9c95cc-7vrvl\` has been in CrashLoopBackOff (~114 restarts in 26m) with three startup errors:

\`\`\`
[ERROR] [Paths][MainDir]: 'MainDir' is required and cannot be empty
[ERROR] [Paths][ScriptDir]: 'ScriptDir' is required and cannot be empty
[ERROR] [Unpack][SevenZipCmd]: "/usr/bin/7za" file doesn't exist
\`\`\`

nzbget v26 made \`MainDir\` and \`ScriptDir\` REQUIRED, and the truecharts/forge image renamed the bundled 7-zip binary from \`/usr/bin/7za\` → \`/usr/bin/7z\`. The persisted \`/config/nzbget.conf\` in the existing PVC predates these changes.

Override the missing keys via nzbget's documented \`-o Section.Key=value\` startup flags through the chart's \`workload.main.podSpec.containers.main.args\` block. **No PVC mutation needed** — clean GitOps fix.

## Test plan

- [ ] CI green
- [ ] After merge + ArgoCD sync:
  - \`kubectl -n media describe statefulset plex-plex-media-server | tail -10\` → no FailedCreate / PodSecurity events
  - \`kubectl -n media get pod plex-plex-media-server-0 -o jsonpath='{.spec.nodeSelector}'\` → contains \`intel.feature.node.kubernetes.io/gpu: "true"\`
  - Plex pod Running on \`talos-lz1-3u1\`
  - \`kubectl -n media exec plex-plex-media-server-0 -- ls /dev/dri\` → \`card0 renderD128\`
  - \`kubectl -n argocd get app plex -o jsonpath='{.status.sync.status}'\` → \`Synced\` (no ComparisonError)
  - \`kubectl -n media get pod -l app.kubernetes.io/name=nzbget\` → Running, restart count not climbing
  - \`kubectl -n media logs -l app.kubernetes.io/name=nzbget --tail=20 | grep -iE "ERROR|maindir|scriptdir|sevenzip"\` → no errors
- [ ] Functional test: play a 4K HEVC file in Plex, dashboard shows hardware transcode indicator

## Out of scope

- The Intel device plugin not advertising \`gpu.intel.com/xe\` is a separate issue. Plugin is Running but produces no advertisement events. Likely Talos \`/dev/dri/by-path\` layout. Tracked separately.