### PR TITLE
fix(nzbget): revert broken -o Section.Key args

### DIFF
--- a/charts/applications/values.yaml
+++ b/charts/applications/values.yaml
@@ -480,20 +480,15 @@ nzbget:
       podSpec:
         containers:
           main:
-            # nzbget v26 made Paths.MainDir and Paths.ScriptDir REQUIRED, and
-            # the truecharts/forge image renamed the bundled 7-zip binary from
-            # /usr/bin/7za to /usr/bin/7z. The persisted /config/nzbget.conf
-            # in the existing PVC predates v26 and is missing all three —
-            # nzbget refuses to start. Override at startup via the documented
-            # `-o Section.Key=value` flags so we don't have to mutate the
-            # config file inside the PVC.
-            args:
-              - "-o"
-              - "Paths.MainDir=/downloads"
-              - "-o"
-              - "Paths.ScriptDir=/config/scripts"
-              - "-o"
-              - "Unpack.SevenZipCmd=/usr/bin/7z"
+            # NOTE: nzbget v26 made `MainDir` and `ScriptDir` REQUIRED and
+            # renamed the bundled 7-zip from /usr/bin/7za to /usr/bin/7z. The
+            # PVC at /config/nzbget.conf has been hand-fixed (lines 11/71/1533)
+            # to set MainDir=/downloads, ScriptDir=/config/scripts, and
+            # SevenZipCmd=/usr/bin/7z. nzbget v26 rejects the dotted
+            # `-o Section.Key=value` CLI override syntax, so we cannot pass
+            # these as args from the chart. If the PVC is ever lost, restore
+            # the same three values via `kubectl exec sed -i ...` after the
+            # pod first crashes.
             resources:
               requests:
                 cpu: 100m

--- a/configuration/templates/helm-apps.tmpl
+++ b/configuration/templates/helm-apps.tmpl
@@ -465,20 +465,11 @@ nzbget:
       podSpec:
         containers:
           main:
-            # nzbget v26 made Paths.MainDir and Paths.ScriptDir REQUIRED, and
-            # the truecharts/forge image renamed the bundled 7-zip binary from
-            # /usr/bin/7za to /usr/bin/7z. The persisted /config/nzbget.conf
-            # in the existing PVC predates v26 and is missing all three —
-            # nzbget refuses to start. Override at startup via the documented
-            # `-o Section.Key=value` flags so we don't have to mutate the
-            # config file inside the PVC.
-            args:
-              - "-o"
-              - "Paths.MainDir=/downloads"
-              - "-o"
-              - "Paths.ScriptDir=/config/scripts"
-              - "-o"
-              - "Unpack.SevenZipCmd=/usr/bin/7z"
+            # NOTE: nzbget v26 made `MainDir` and `ScriptDir` REQUIRED and
+            # renamed the bundled 7-zip from /usr/bin/7za to /usr/bin/7z.
+            # nzbget v26 rejects the dotted `-o Section.Key=value` CLI
+            # override syntax, so we cannot pass these as args from the chart.
+            # The PVC at /config/nzbget.conf is hand-fixed (lines 11/71/1533).
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Summary

PR #230 added container \`args\` to override the missing nzbget v26 config keys via \`-o Paths.MainDir=...\`. **nzbget v26 rejects the dotted Section.Key syntax for CLI overrides:**

\`\`\`
[ERROR] nzbget.conf(306): Invalid option "Paths.MainDir"
[ERROR] nzbget.conf(306): Invalid option "Paths.ScriptDir"
[ERROR] nzbget.conf(306): Invalid option "Unpack.SevenZipCmd"
[INFO] Pausing all activities due to errors in configuration
\`\`\`

Verified the args reach nzbget correctly via \`ps -ef\` inside the pod:

\`\`\`
/app/nzbget --server --configfile /config/nzbget.conf -o OutputMode=log \\
  -o ControlPort=6789 \\
  -o Paths.MainDir=/downloads -o Paths.ScriptDir=/config/scripts \\
  -o Unpack.SevenZipCmd=/usr/bin/7z
\`\`\`

So this is nzbget v26 dropping the CLI override syntax we relied on, not a truecharts entrypoint problem.

## Fix

Remove the broken \`args\` block from both \`charts/applications/values.yaml\` and \`configuration/templates/helm-apps.tmpl\`. Fix the config the only other way that works: edit \`/config/nzbget.conf\` in the PVC directly. The conf file already had placeholder lines for all three keys that just needed values:

| line | before | after |
|---|---|---|
| 11 | \`MainDir=\` | \`MainDir=/downloads\` |
| 71 | \`ScriptDir=\` | \`ScriptDir=/config/scripts\` |
| 1533 | \`SevenZipCmd=/usr/bin/7za\` | \`SevenZipCmd=/usr/bin/7z\` |

Also created \`/config/scripts/\` since v26 refuses to start if ScriptDir points to a missing directory.

Both edits applied via \`kubectl exec sed -i ...\` against the live PVC. They persist across pod restarts because the PVC is on NFS. If the PVC is ever lost, the same three sed commands need to be re-applied after the next crash. Documented in the chart values comment for the next operator who hits this.

## Test plan

- [ ] CI green
- [ ] After merge + ArgoCD sync, nzbget pod no longer has the \`-o Paths.MainDir=...\` args in its command line
- [ ] \`kubectl -n media logs -l app.kubernetes.io/name=nzbget --tail=20 | grep -iE 'error|maindir|scriptdir|sevenzip'\` → no errors
- [ ] nzbget web UI loads at https://nzbget.ryanmcafee.com
- [ ] Pod shows steady restart count (not climbing)

## Follow-up

A proper GitOps fix for nzbget config (so a fresh PVC has the right values from day 1) would either:
- Use truecharts' \`configFiles\` value to provide a full \`nzbget.conf\` from a chart-managed configmap
- Or add an init container to the workload that runs the same sed before nzbget starts

Out of scope here — the live cluster is unblocked and that's a pre-existing rough edge.