### PR TITLE
fix(nzbget): bump memory to 2Gi to stop v26 startup OOMKill

### DIFF
--- a/charts/applications/values.yaml
+++ b/charts/applications/values.yaml
@@ -490,12 +490,17 @@ nzbget:
             # the same three values via `kubectl exec sed -i ...` after the
             # pod first crashes.
             resources:
+              # Bumped from 256Mi/1Gi after nzbget-584d9c95cc-jwnkg was OOMKilled
+              # within 7 seconds of startup on a 1Gi limit. v26 of nzbget appears
+              # to use significantly more memory at startup than v25 (probably
+              # due to the new par2 + unpack subsystems). 1Gi was sufficient
+              # historically; bump to 2Gi to give headroom for active unpacking.
               requests:
                 cpu: 100m
-                memory: 256Mi
+                memory: 512Mi
               limits:
                 cpu: 2000m
-                memory: 1Gi
+                memory: 2Gi
 
   # Persistence configuration
   persistence:

--- a/configuration/templates/helm-apps.tmpl
+++ b/configuration/templates/helm-apps.tmpl
@@ -471,12 +471,15 @@ nzbget:
             # override syntax, so we cannot pass these as args from the chart.
             # The PVC at /config/nzbget.conf is hand-fixed (lines 11/71/1533).
             resources:
+              # Bumped from 256Mi/1Gi after nzbget v26 OOMKilled within 7s of
+              # startup on the old 1Gi limit. v26 uses significantly more
+              # memory than v25 (likely the new par2/unpack subsystems).
               requests:
                 cpu: 100m
-                memory: 256Mi
+                memory: 512Mi
               limits:
                 cpu: 1000m
-                memory: 1Gi
+                memory: 2Gi
 
   persistence:
     config:


### PR DESCRIPTION
## Summary

After PR #231 reverted the broken \`-o\` args, the new nzbget pod gets OOMKilled in **7 seconds** of startup on the historical 1Gi memory limit.

## Why

\`\`\`json
{
  "lastState": {
    "terminated": {
      "reason": "OOMKilled",
      "exitCode": 137,
      "startedAt":  "2026-04-11T21:33:44Z",
      "finishedAt": "2026-04-11T21:33:51Z"
    }
  },
  "limits": {"cpu": "1", "memory": "1Gi"}
}
\`\`\`

1Gi was sufficient for nzbget v25 historically. v26 uses significantly more memory at startup — likely the new par2 + unpack subsystems eagerly allocating buffers. Bump request 256Mi → 512Mi and limit 1Gi → 2Gi.

## Test plan

- [ ] CI green
- [ ] After merge: \`kubectl -n media get pod -l app.kubernetes.io/name=nzbget\` shows 1/1 Running, restart count steady
- [ ] \`kubectl -n media logs -l app.kubernetes.io/name=nzbget --tail=20 | grep -iE 'error|oom'\` → no errors

## Context

This is the 8th PR in the Plex Intel GPU + media stack work this session (#225-#232). Plex is now hardware-transcoding via the Intel B50; nzbget is the last open issue.