### PR TITLE
fix(nzbget): bump memory to 4Gi (2Gi still OOMs mid-unrar)

### DIFF
--- a/charts/applications/values.yaml
+++ b/charts/applications/values.yaml
@@ -490,17 +490,19 @@ nzbget:
             # the same three values via `kubectl exec sed -i ...` after the
             # pod first crashes.
             resources:
-              # Bumped from 256Mi/1Gi after nzbget-584d9c95cc-jwnkg was OOMKilled
-              # within 7 seconds of startup on a 1Gi limit. v26 of nzbget appears
-              # to use significantly more memory at startup than v25 (probably
-              # due to the new par2 + unpack subsystems). 1Gi was sufficient
-              # historically; bump to 2Gi to give headroom for active unpacking.
+              # Bumped from 256Mi/1Gi → 512Mi/2Gi → 1Gi/4Gi as nzbget v26 keeps
+              # OOMing on the previous limit. At 1Gi: dead in 7s during startup.
+              # At 2Gi: survives ~88s into active unrar of large files (Captain
+              # America REMUX HEVC, BluRay-class) before OOMKill. v26's par2 +
+              # unpack subsystems hold the entire output buffer in memory while
+              # extracting, so peaks track the largest file in the archive set.
+              # 4Gi gives headroom for 4K BluRay REMUX (~50GB) extractions.
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 1Gi
               limits:
                 cpu: 2000m
-                memory: 2Gi
+                memory: 4Gi
 
   # Persistence configuration
   persistence:

--- a/configuration/templates/helm-apps.tmpl
+++ b/configuration/templates/helm-apps.tmpl
@@ -471,15 +471,18 @@ nzbget:
             # override syntax, so we cannot pass these as args from the chart.
             # The PVC at /config/nzbget.conf is hand-fixed (lines 11/71/1533).
             resources:
-              # Bumped from 256Mi/1Gi after nzbget v26 OOMKilled within 7s of
-              # startup on the old 1Gi limit. v26 uses significantly more
-              # memory than v25 (likely the new par2/unpack subsystems).
+              # Bumped from 256Mi/1Gi → 512Mi/2Gi → 1Gi/4Gi as nzbget v26 kept
+              # OOMing on smaller limits. At 1Gi: dead in 7s during startup.
+              # At 2Gi: survives ~88s into active unrar of large files before
+              # OOMKill. v26's par2 + unpack subsystems hold the entire output
+              # buffer in memory while extracting, so peaks track the largest
+              # file in the archive set (4K BluRay REMUX easily exceeds 2Gi).
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 1Gi
               limits:
                 cpu: 1000m
-                memory: 2Gi
+                memory: 4Gi
 
   persistence:
     config:


### PR DESCRIPTION
## Summary

PR #232 bumped from 1Gi → 2Gi which got nzbget past startup, but the pod is **still OOMKilled mid-unpack** on large files.

## Why

\`\`\`json
{
  "lastState": {
    "terminated": {
      "reason": "OOMKilled",
      "exitCode": 137,
      "startedAt":  "2026-04-11T21:41:12Z",
      "finishedAt": "2026-04-11T21:42:40Z"
    }
  },
  "limits": {"memory": "2Gi"}
}
\`\`\`

88 seconds into active unrar of a Captain America BluRay REMUX HEVC archive (4K REMUX, ~50GB). nzbget v26's par2 + unpack subsystems hold the entire output buffer in memory while extracting, so peak RSS scales with the largest file in the archive set.

Bump request 512Mi → 1Gi and limit 2Gi → 4Gi. 4Gi is sufficient for 4K BluRay REMUX peaks observed in the live workload.

## Test plan

- [ ] CI green
- [ ] After merge: nzbget pod 1/1 Running, restart count steady, no OOMKill events for at least 5 min during active unpack