### PR TITLE
fix(external-dns): add ingress-class filter to UniFi instance

### DIFF
--- a/charts/addons/templates/external-dns-unifi.yaml
+++ b/charts/addons/templates/external-dns-unifi.yaml
@@ -189,6 +189,7 @@ spec:
 
         extraArgs:
           - --annotation-filter=external-dns.alpha.kubernetes.io/hostname
+          - --ingress-class=internal
           - --txt-owner-id=homelab-unifi-ingress
 
         domainFilters:


### PR DESCRIPTION
## Summary
- Adds `--ingress-class=internal` to the `external-dns-unifi-ingress` deployment extraArgs
- The UniFi external-dns instance had no ingress-class filter, so it watched ALL ingresses including the `external`-class Plex ingress
- Every reconciliation cycle it tried to create a `plex.ryanmcafee.com` CNAME on the UniFi gateway, hit a `CNAME Alias Overlaps With Other Records` 400 error, and the **entire `ApplyChanges` batch failed** — blocking DNS record creation for all internal ingresses (sonarr, radarr, grafana, etc.) for 65,830+ consecutive errors (~46 days)
- This matches the Cloudflare instance's existing `--ingress-class=external` pattern

## Test plan
- [ ] Helm lint/template pre-commit hooks pass
- [ ] After merge + ArgoCD sync, verify `external-dns-unifi-ingress` pod restarts with new args
- [ ] Verify webhook logs no longer show plex CNAME errors
- [ ] Verify `dig sonarr.ryanmcafee.com @172.16.100.1` returns an A record
- [ ] Verify `dig radarr.ryanmcafee.com @172.16.100.1` returns an A record